### PR TITLE
Fix static file serving path when using copyPath

### DIFF
--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -13,6 +13,7 @@ module.exports = () => {
   const webpack = require('webpack');
   const chalk = require('chalk');
   const detectPort = require('detect-port');
+  const paths = require('./paths');
 
   detectPort(config.WEBPACK_PORT, (_, freePort) => {
     if (config.WEBPACK_PORT !== freePort) {
@@ -37,6 +38,7 @@ module.exports = () => {
       inline: false,
       host: config.WEBPACK_DOMAIN,
       publicPath: `${config.WEBPACK_SERVER}/`,
+      contentBase: `${paths.PUBLIC_DIRECTORY}`,
       hot: true,
       watchOptions: {
         ignored: /node_modules/,


### PR DESCRIPTION
The static files were served from the non-public path of project root prior to this change. Adding `contentBase` with `PUBLIC_DIRECTORY` path as the value to the webpack-dev-server configuration makes the static files be served relative to the public path, not the project root. The static file path prior to change, with `public/` as the public directory: `/public/copiedFolder/file.jpg`. After the change: `/copiedFolder/file.jpg`.