### PR TITLE
Make it possible to skip server-side rendering for universal-react

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@
 export default async function renderOnServer(ReactComponent, url, props = {}, cspNonce) {} // Declaration
 const { content, context } = await render(App, req.originalUrl, { config: getConfig() }, res.locals.cspNonce); // Usage
 // After
-export default async function renderOnServer(ReactComponent, url, props = {}, { config, cspNonce, appDecorator, document }) {} // Declaration
+export default async function renderOnServer(ReactComponent, url, props = {}, { cspNonce, appDecorator, document, config } = {}) {} // Declaration
 const { content, context } = await render(App, req.originalUrl, {}, { config: getConfig(), cspNonce: res.locals.cspNonce }); // Usage
 ```
 
 - Added possibility to override the HTML document template in universal-react.
-- Added `appDecorator` option in universal-react server render method to add a wrapper function around the entire React app before passing it to `ReactDOMServer.renderToString()`
+- Added `appDecorator` option in universal-react server render method to add a wrapper function around the entire React app before passing it to `ReactDOMServer.renderToString()`.
+- Config object is now passed to client also in a case when server-side rendering fails in universal-react.
+- Add optional `DISABLE_SSR` environment variable to disable server-side rendering in universal-react.
 
 ## [17.0.0] - 2021-06-02
 

--- a/docs/universal-react.md
+++ b/docs/universal-react.md
@@ -48,6 +48,9 @@ render(ReactComponent, domNode, props);
  *              Otherwise you will get content mismatch errors during hydration.
  * @param cspNonce (optional) - Sets the `nonce` attribute on the <script> element that create-frontend uses.
  *                 Used for the script-src directive when implementing a content-security-policy.
+ * @param appDecorator (optional) - Decorator function to wrap the entire React app before getting passed to renderToString mehtod
+ * @param document (optional) - Overrideable HTML document template
+ * @param config (optional) - Configuration object that get rendered both on the server and client side. Be careful as the values get exposed to the client.
  *
  * @return {{ content: String, context: Object }}
  */
@@ -55,7 +58,7 @@ import { render } from '@optimistdigital/create-frontend/universal-react/server'
 const {
     content, // App rendered to string
     context, // Server-side context, for passing data to from the React app to the server
-} = render(ReactComponent, url, backendData, res.locals.cspNonce);
+} = render(ReactComponent, url, props, { cspNonce, appDecorator, document, config });
 ```
 
 ## Configuration

--- a/eslint-config-vanilla.js
+++ b/eslint-config-vanilla.js
@@ -26,5 +26,6 @@ module.exports = {
     __OCF_MANIFEST_PATH__: true,
     __TARGET__: true,
     __USE_STYLED_JSX__: true,
+    __SSR_DISABLED__: true,
   },
 };

--- a/scripts/templates/universal-react/server/entry.js
+++ b/scripts/templates/universal-react/server/entry.js
@@ -19,8 +19,8 @@ server.use('/', async (req, res) => {
     const { content, context } = await render(
       App,
       req.originalUrl,
-      { config: getConfig() },
-      { cspNonce: res.locals.cspNonce }
+      {},
+      { config: getConfig(), cspNonce: res.locals.cspNonce }
     );
 
     // If there was a redirect in the app, redirect here
@@ -34,7 +34,7 @@ server.use('/', async (req, res) => {
     console.error('Error while rendering React, skipping SSR:', err);
 
     // If SSR failed, send an empty page so client can try to render
-    return res.status(500).send((await render(null, req.originalUrl, { config: getConfig() })).content);
+    return res.status(500).send((await render(null, req.originalUrl, {}, { config: getConfig() })).content);
   }
 });
 

--- a/scripts/webpack/getWebpackConfig.js
+++ b/scripts/webpack/getWebpackConfig.js
@@ -337,6 +337,7 @@ module.exports = async target => {
       __DEBUG__: process.env.APP_DEBUG === 'true',
       __OCF_MANIFEST_PATH__: JSON.stringify(config.MANIFEST_PATH),
       __USE_STYLED_JSX__: config.USE_STYLED_JSX,
+      __SSR_DISABLED__: process.env.DISABLE_SSR === 'true',
     }),
   ];
 

--- a/universal-react/server/render.js
+++ b/universal-react/server/render.js
@@ -15,10 +15,15 @@ import urlParser from 'url';
  *
  * @return {{ content: String, context: Object }}
  */
-export default async function renderOnServer(ReactComponent, url, props = {}, { cspNonce, appDecorator, document }) {
+export default async function renderOnServer(
+  ReactComponent,
+  url,
+  props = {},
+  { cspNonce, appDecorator, document, config } = {}
+) {
   const serverContext = {};
   const helmetContext = {};
-  const appData = { url, pageData: {}, config: props.config };
+  const appData = { url, pageData: { config } };
   ReactComponent = __SSR_DISABLED__ ? null : ReactComponent;
 
   /**

--- a/universal-react/server/render.js
+++ b/universal-react/server/render.js
@@ -18,7 +18,8 @@ import urlParser from 'url';
 export default async function renderOnServer(ReactComponent, url, props = {}, cspNonce) {
   const serverContext = {};
   const helmetContext = {};
-  const appData = { url, pageData: {} };
+  const appData = { url, pageData: {}, config: props.config };
+  ReactComponent = __SSR_DISABLED__ ? null : ReactComponent;
 
   /**
    * Get page data


### PR DESCRIPTION
For making it easier to test apps built on create-frontend universal-react template using Cypress it's handy when server-side rendering can be disabled. This also means that passing configuration from server to client must also work when the React app is not rendered on the server.