### PR TITLE
Make it possible to override document within the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@
 - Breaking change in universal-react's `renderOnServer()` arguments.
 
 ```js
-// After
-export default async function renderOnServer(ReactComponent, url, props = {}, cspNonce) {} // Declaration
-const { content, context } = await render(App, req.originalUrl, {}, { config: getConfig(), cspNonce: res.locals.cspNonce }); // Usage
 // Before
-export default async function renderOnServer(ReactComponent, url, props = {}, { config, cspNonce, appDecorator, document }) {} // Declaration
+export default async function renderOnServer(ReactComponent, url, props = {}, cspNonce) {} // Declaration
 const { content, context } = await render(App, req.originalUrl, { config: getConfig() }, res.locals.cspNonce); // Usage
+// After
+export default async function renderOnServer(ReactComponent, url, props = {}, { config, cspNonce, appDecorator, document }) {} // Declaration
+const { content, context } = await render(App, req.originalUrl, {}, { config: getConfig(), cspNonce: res.locals.cspNonce }); // Usage
 ```
 
 - Added possibility to override the HTML document template in universal-react.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [18.0.0] - 2022-01-xx
+
+- Breaking change in universal-react's `renderOnServer()` arguments.
+
+```js
+// After
+export default async function renderOnServer(ReactComponent, url, props = {}, cspNonce) {} // Declaration
+const { content, context } = await render(App, req.originalUrl, {}, { config: getConfig(), cspNonce: res.locals.cspNonce }); // Usage
+// Before
+export default async function renderOnServer(ReactComponent, url, props = {}, { config, cspNonce, appDecorator, document }) {} // Declaration
+const { content, context } = await render(App, req.originalUrl, { config: getConfig() }, res.locals.cspNonce); // Usage
+```
+
+- Added possibility to override the HTML document template in universal-react.
+- Added `appDecorator` option in universal-react server render method to add a wrapper function around the entire React app before passing it to `ReactDOMServer.renderToString()`
+
 ## [17.0.0] - 2021-06-02
 
 Reworked server startup logic, fixing issues with hot reload, which would sometimes cause the server to stop updating during development.

--- a/docs/universal-react.md
+++ b/docs/universal-react.md
@@ -147,7 +147,7 @@ This content is then available in the `context` property after the server render
 import { render } from '@optimistdigital/create-frontend/universal-react/server';
 
 // Render the app
-const { content, context } = render(ReactComponent, request, config);
+const { content, context } = render(ReactComponent, url, props, options);
 
 // Read status from server context, with 200 as the default
 return res.status(context.status || 200).send(content);

--- a/scripts/templates/universal-react/server/entry.js
+++ b/scripts/templates/universal-react/server/entry.js
@@ -16,7 +16,12 @@ server.get(/\.(\w+)$/, (req, res) => res.status(404).send('Not found')); // Don'
 server.use('/', async (req, res) => {
   try {
     // Render the app
-    const { content, context } = await render(App, req.originalUrl, { config: getConfig() }, res.locals.cspNonce);
+    const { content, context } = await render(
+      App,
+      req.originalUrl,
+      { config: getConfig() },
+      { cspNonce: res.locals.cspNonce }
+    );
 
     // If there was a redirect in the app, redirect here
     if (context.url) {

--- a/universal-react/server/document.js
+++ b/universal-react/server/document.js
@@ -1,0 +1,26 @@
+import serialize from 'serialize-javascript';
+
+export default function document({ content, manifest, styles, helmet, appData, cspNonce, inlineStyles }) {
+  return `<!doctype html>
+    <html ${helmet.htmlAttributes.toString()}>
+      <head>
+        <meta charset="UTF-8">
+        ${helmet.title.toString()}
+        ${helmet.meta.toString()}
+        ${helmet.link.toString()}
+        ${manifest['app.css'] ? `<link rel="stylesheet" href="${manifest['app.css']}">` : ''}
+        ${__DEVELOPMENT__ && styles ? `<style id="ocf-server-styles">${styles.join('\n')}</style>` : ''}
+        ${helmet.script.toString()}
+        ${helmet.noscript.toString()}
+        ${helmet.style.toString()}
+        ${inlineStyles.join('')}
+      </head>
+      <body ${helmet.bodyAttributes.toString()}>
+        <div id="react-app">${content}</div>
+        <script${cspNonce ? ` nonce="${cspNonce}" ` : ''}>Object.defineProperty(window, '__OCF_APP_DATA__', {
+          value: ${serialize(appData)}
+        });</script>
+        <script ${__DEVELOPMENT__ ? 'crossorigin ' : ''}src="${manifest['app.js']}"></script>
+      </body>
+    </html>`;
+}

--- a/universal-react/server/render.js
+++ b/universal-react/server/render.js
@@ -15,7 +15,7 @@ import urlParser from 'url';
  *
  * @return {{ content: String, context: Object }}
  */
-export default async function renderOnServer(ReactComponent, url, props = {}, cspNonce) {
+export default async function renderOnServer(ReactComponent, url, props = {}, { cspNonce, appDecorator, document }) {
   const serverContext = {};
   const helmetContext = {};
   const appData = { url, pageData: {} };
@@ -41,18 +41,20 @@ export default async function renderOnServer(ReactComponent, url, props = {}, cs
     appData.skippedSSR = true;
   }
 
-  /**
-   * Render app to string
-   */
-  const appString = ReactDOMServer.renderToString(
+  const ReactApp = (
     <AppDataContext.Provider value={{ ...appData, serverContext }}>
       <HelmetProvider context={helmetContext}>{ReactComponent ? <ReactComponent {...props} /> : ' '}</HelmetProvider>
     </AppDataContext.Provider>
   );
+
+  /**
+   * Render app to string
+   */
+  const appString = ReactDOMServer.renderToString(appDecorator ? appDecorator(ReactApp) : ReactApp);
   const jsxStyles = __USE_STYLED_JSX__ ? require('styled-jsx/server').flushToHTML({ nonce: cspNonce }) : null;
 
   return {
-    content: wrapInDocument(appString, appData, helmetContext, cspNonce, [jsxStyles]),
+    content: wrapInDocument(appString, appData, helmetContext, cspNonce, [jsxStyles], document),
     context: serverContext,
   };
 }

--- a/universal-react/server/wrapInDocument.js
+++ b/universal-react/server/wrapInDocument.js
@@ -31,11 +31,8 @@ export default function wrapInDocument(
   helmetContext,
   cspNonce,
   inlineStyles = [],
-  overriddenDocument
+  document = defaultDocument
 ) {
-  /* App can override the document, otherwise use a default one */
-  const document = overriddenDocument ? overriddenDocument : defaultDocument;
-
   /* Get dev-only styles, to prevent FOUC. This is a virtual file injected by the dev server. */
   const styles = __DEVELOPMENT__ ? require('ocf-dev-styles.js') : [];
 

--- a/universal-react/server/wrapInDocument.js
+++ b/universal-react/server/wrapInDocument.js
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import serialize from 'serialize-javascript';
+import defaultDocument from './document';
 
 let _manifest;
 function getManifest() {
@@ -25,7 +25,17 @@ function getManifest() {
   return _manifest;
 }
 
-export default function wrapInDocument(content, appData, helmetContext, cspNonce, inlineStyles = []) {
+export default function wrapInDocument(
+  content,
+  appData,
+  helmetContext,
+  cspNonce,
+  inlineStyles = [],
+  overriddenDocument
+) {
+  /* App can override the document, otherwise use a default one */
+  const document = overriddenDocument ? overriddenDocument : defaultDocument;
+
   /* Get dev-only styles, to prevent FOUC. This is a virtual file injected by the dev server. */
   const styles = __DEVELOPMENT__ ? require('ocf-dev-styles.js') : [];
 
@@ -34,26 +44,5 @@ export default function wrapInDocument(content, appData, helmetContext, cspNonce
 
   const manifest = getManifest();
 
-  return `<!doctype html>
-<html ${helmet.htmlAttributes.toString()}>
-  <head>
-    <meta charset="UTF-8">
-    ${helmet.title.toString()}
-    ${helmet.meta.toString()}
-    ${helmet.link.toString()}
-    ${manifest['app.css'] ? `<link rel="stylesheet" href="${manifest['app.css']}">` : ''}
-    ${__DEVELOPMENT__ && styles ? `<style id="ocf-server-styles">${styles.join('\n')}</style>` : ''}
-    ${helmet.script.toString()}
-    ${helmet.noscript.toString()}
-    ${helmet.style.toString()}
-    ${inlineStyles.join('')}
-  </head>
-  <body ${helmet.bodyAttributes.toString()}>
-    <div id="react-app">${content}</div>
-    <script${cspNonce ? ` nonce="${cspNonce}" ` : ''}>Object.defineProperty(window, '__OCF_APP_DATA__', {
-      value: ${serialize(appData)}
-    });</script>
-    <script ${__DEVELOPMENT__ ? 'crossorigin ' : ''}src="${manifest['app.js']}"></script>
-  </body>
-</html>`;
+  return document({ content, manifest, styles, helmet, appData, cspNonce, inlineStyles });
 }


### PR DESCRIPTION
Tarvo, Kaspar and other have had problems with create-frontend because they have needed to override the document HTML and decorate the rendered React app on the server-side. This should be a solution to these problems.